### PR TITLE
Fix help output columns align

### DIFF
--- a/src/Command/REPLCommand.php
+++ b/src/Command/REPLCommand.php
@@ -215,4 +215,12 @@ EOW
 
         return sprintf($message, $this->application->getScript(), $this->definition->getArgSynopsis());
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getUsage($tab = Formatter::TAB, $width = 24)
+    {
+        return parent::getUsage($tab, $width);
+    }
 }


### PR DESCRIPTION
- Increase `REPLCommand::getUsage()` columns default minimal left-padding to `24`